### PR TITLE
Fix AddPrefixToColumns methods

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,13 +10,16 @@ from PIL import Image
 class AddPrefixToColumns(BaseEstimator, TransformerMixin):
     def __init__(self, prefix=""):
         self.prefix = prefix
-def fit(self, X, y=None):
-    return self
 
-def transform(self, X):
-    X = X.copy()
-    X.columns = [f"{self.prefix}{col}" for col in X.columns]
-    return X
+    def fit(self, X, y=None):
+        # Store original column names to avoid prefixing multiple times
+        self.feature_names_in_ = list(X.columns)
+        return self
+
+    def transform(self, X):
+        X = X.copy()
+        X.columns = [f"{self.prefix}{col}" for col in self.feature_names_in_]
+        return X
 
 def eliminar_duplicados(data):
     data.drop_duplicates(inplace=True, keep='first')


### PR DESCRIPTION
## Summary
- ensure AddPrefixToColumns includes fit and transform as methods
- store original column names in fit to avoid repeated prefixing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68463a06c86c8330899a2c253515cf64